### PR TITLE
Dev 1.1.0 #31 prompt confirmation on reset

### DIFF
--- a/src/chat-registry.js
+++ b/src/chat-registry.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 /**
  * Imports
@@ -11,53 +11,53 @@ const DankTime = require('./dank-time.js');
  */
 class ChatRegistry {
 
-    /**
-     * Instantiates a new chat registry.
-     * @param {Map<number,Chat>} chats The initial chats.
-     */
-    constructor(chats = new Map()) {
-        this.setChats(chats);
+  /**
+   * Instantiates a new chat registry.
+   * @param {Map<number,Chat>} chats The initial chats.
+   */
+  constructor(chats = new Map()) {
+    this.setChats(chats);
+  }
+
+  /**
+   * Sets the chats.
+   * @param {Map<number,Chat>} newchats
+   */
+  setChats(newchats) {
+    if (!(newchats instanceof Map)) {
+      throw TypeError('The chats should be a map!');
     }
+    this._chats = newchats;
+  };
 
-    /**
-     * Sets the chats.
-     * @param {Map<number,Chat>} newchats
-     */
-    setChats(newchats) {
-        if (!(newchats instanceof Map)) {
-            throw TypeError('The chats should be a map!');
-        }
-        this._chats = newchats;
-    };
+  /**
+   * Gets the map containing all chats.
+   * @returns {Map<number,Chat>}
+   */
+  getChats() {
+    return this._chats;
+  };
 
-    /**
-     * Gets the map containing all chats.
-     * @returns {Map<number,Chat>}
-     */
-    getChats() {
-        return this._chats;
-    };
-
-    /**
-     * Gets the chat with the supplied id, otherwise creates and returns a new one.
-     * @param {number} id The chat's unique Telegram id.
-     * @returns {Chat} The (possibly new) chat.
-     */
-    getOrCreateChat(id) {
-        if (this._chats.has(id)) {
-            return this._chats.get(id);
-        }
-        const chat = new Chat(id);
-        chat.addDankTime(new DankTime(0, 0, ['0000'], 5));
-        chat.addDankTime(new DankTime(4, 20, ['420'], 15));
-        chat.addDankTime(new DankTime(11, 11, ['1111'], 5));
-        chat.addDankTime(new DankTime(12, 34, ['1234'], 5));
-        chat.addDankTime(new DankTime(13, 37, ['1337'], 10));
-        chat.addDankTime(new DankTime(16, 20, ['420'], 10));
-        chat.addDankTime(new DankTime(22, 22, ['2222'], 5));
-        this._chats.set(id, chat);
-        return chat;
-    };
+  /**
+   * Gets the chat with the supplied id, otherwise creates and returns a new one.
+   * @param {number} id The chat's unique Telegram id.
+   * @returns {Chat} The (possibly new) chat.
+   */
+  getOrCreateChat(id) {
+    if (this._chats.has(id)) {
+      return this._chats.get(id);
+    }
+    const chat = new Chat(id);
+    chat.addDankTime(new DankTime(0, 0, ['0000'], 5));
+    chat.addDankTime(new DankTime(4, 20, ['420'], 15));
+    chat.addDankTime(new DankTime(11, 11, ['1111'], 5));
+    chat.addDankTime(new DankTime(12, 34, ['1234'], 5));
+    chat.addDankTime(new DankTime(13, 37, ['1337'], 10));
+    chat.addDankTime(new DankTime(16, 20, ['420'], 10));
+    chat.addDankTime(new DankTime(22, 22, ['2222'], 5));
+    this._chats.set(id, chat);
+    return chat;
+  };
 };
 
 // Exports.

--- a/src/chat.js
+++ b/src/chat.js
@@ -11,422 +11,422 @@ const User = require('./user.js');
  */
 class Chat {
 
-    /**
-     * Creates a new Chat object.
-     * @param {number} id The chat's unique Telegram id.
-     * @param {string} timezone The timezone the users are in.
-     * @param {boolean} running Whether this bot is running for this chat.
-     * @param {number} numberOfRandomTimes The number of randomly generated dank times to generate each day.
-     * @param {number} pointsPerRandomTime The number of points each randomly generated dank time is worth.
-     * @param {number} lastHour The hour of the last valid dank time being proclaimed.
-     * @param {number} lastMinute The minute of the last valid dank time being proclaimed.
-     * @param {User[]} users A map with the users, indexed by user id's.
-     * @param {DankTime[]} dankTimes The dank times known in this chat.
-     * @param {DankTime[]} randomDankTimes The daily randomly generated dank times in this chat.
-     */
-    constructor(id, timezone = 'Europe/Amsterdam', running = false, numberOfRandomTimes = 1, pointsPerRandomTime = 10,
-        lastHour = 0, lastMinute = 0, users = new Map(), dankTimes = [], randomDankTimes = []) {
-        if (typeof id !== 'number' || id % 1 !== 0) {
-            throw TypeError('The id must be a whole number!');
+  /**
+   * Creates a new Chat object.
+   * @param {number} id The chat's unique Telegram id.
+   * @param {string} timezone The timezone the users are in.
+   * @param {boolean} running Whether this bot is running for this chat.
+   * @param {number} numberOfRandomTimes The number of randomly generated dank times to generate each day.
+   * @param {number} pointsPerRandomTime The number of points each randomly generated dank time is worth.
+   * @param {number} lastHour The hour of the last valid dank time being proclaimed.
+   * @param {number} lastMinute The minute of the last valid dank time being proclaimed.
+   * @param {User[]} users A map with the users, indexed by user id's.
+   * @param {DankTime[]} dankTimes The dank times known in this chat.
+   * @param {DankTime[]} randomDankTimes The daily randomly generated dank times in this chat.
+   */
+  constructor(id, timezone = 'Europe/Amsterdam', running = false, numberOfRandomTimes = 1, pointsPerRandomTime = 10,
+    lastHour = 0, lastMinute = 0, users = new Map(), dankTimes = [], randomDankTimes = []) {
+    if (typeof id !== 'number' || id % 1 !== 0) {
+      throw TypeError('The id must be a whole number!');
+    }
+    this._id = id;
+    this.setTimezone(timezone);
+    this.setRunning(running);
+    this.setLastHour(lastHour);
+    this.setLastMinute(lastMinute);
+    if (!(users instanceof Map)) {
+      throw TypeError('The users must be a map!');
+    }
+    this._users = users;
+    if (!(dankTimes instanceof Array)) {
+      throw TypeError('The dank times must be a array!');
+    }
+    this._dankTimes = dankTimes;
+    if (!(randomDankTimes instanceof Array)) {
+      throw TypeError('The random dank times must be a array!');
+    }
+    this._randomDankTimes = randomDankTimes;
+    this.setNumberOfRandomTimes(numberOfRandomTimes);
+    this.setPointsPerRandomTime(pointsPerRandomTime);
+    this._awaitingResetConfirmation = false;
+  }
+
+  /**
+   * Sets the timezone the users are in.
+   * @param {string} newtimezone
+   */
+  setTimezone(newtimezone) {
+    try {
+      new Date().setTimezone(newtimezone);
+    } catch (err) {
+      throw RangeError('Invalid timezone! Examples: \'Europe/Amsterdam\', \'UTC\'.');
+    }
+    this._timezone = newtimezone;
+  };
+
+  /**
+   * Sets whether this bot is running for this chat.
+   * @param {boolean} newrunning
+   */
+  setRunning(newrunning) {
+    if (typeof newrunning !== 'boolean') {
+      throw TypeError('The running state must be a boolean!');
+    }
+    this._running = newrunning;
+  };
+
+  /**
+   * Sets the number of randomly generated dank times to generate each day.
+   * @param {number} newnumberOfRandomTimes
+   * @returns {DankTime[]} The removed times if the old number was > than the new number.
+   */
+  setNumberOfRandomTimes(newnumberOfRandomTimes) {
+    if (typeof newnumberOfRandomTimes !== 'number' || newnumberOfRandomTimes < 0 || newnumberOfRandomTimes % 1 !== 0) {
+      throw TypeError('The number of times must be a whole number greater or equal to 0!');
+    }
+    this._numberOfRandomTimes = newnumberOfRandomTimes;
+    return this._randomDankTimes.splice(newnumberOfRandomTimes)
+  };
+
+  /**
+   * Sets the number of points each randomly generated dank time is worth.
+   * @param {number} newpointsPerRandomTime
+   */
+  setPointsPerRandomTime(newpointsPerRandomTime) {
+    if (typeof newpointsPerRandomTime !== 'number' || newpointsPerRandomTime < 1 || newpointsPerRandomTime % 1 !== 0) {
+      throw TypeError('The points must be a whole number greater than 0!');
+    }
+    this._pointsPerRandomTime = newpointsPerRandomTime;
+
+    // Update existing random times.
+    this._randomDankTimes.forEach(time => time.setPoints(newpointsPerRandomTime));
+  };
+
+  /**
+   * Sets the hour of the last valid dank time being proclaimed.
+   * @param {number} newlastHour
+   */
+  setLastHour(newlastHour) {
+    if (typeof newlastHour !== 'number' || newlastHour < 0 || newlastHour > 23 || newlastHour % 1 !== 0) {
+      throw TypeError('The hour must be a whole number between 0 and 23!');
+    }
+    this._lastHour = newlastHour;
+  };
+
+  /**
+   * Sets the minute of the last valid dank time being proclaimed.
+   * @param {number} newlastMinute
+   */
+  setLastMinute(newlastMinute) {
+    if (typeof newlastMinute !== 'number' || newlastMinute < 0 || newlastMinute > 59 || newlastMinute % 1 !== 0) {
+      throw TypeError('The minute must be a whole number between 0 and 59!');
+    }
+    this._lastMinute = newlastMinute;
+  };
+
+  /**
+   * Adds a new normal dank time to this chat, replacing any dank time that has
+   * the same hour and minute.
+   * @param {DankTime} dankTime
+   */
+  addDankTime(dankTime) {
+    const existing = this._getDankTime(dankTime.getHour(), dankTime.getMinute());
+    if (existing) {
+      this._dankTimes.splice(this._dankTimes.indexOf(existing), 1);
+    }
+    this._dankTimes.push(dankTime);
+  };
+
+  /**
+   * Adds a user to this chat.
+   * @param {User} user The user to add.
+   */
+  addUser(user) {
+    this._users.set(user.id, user);
+  };
+
+  /**
+   * Gets the timezone the users are in.
+   * @returns {string}
+   */
+  getTimezone() {
+    return this._timezone;
+  };
+
+  /**
+   * Gets whether this bot is running for this chat.
+   * @returns {boolean}
+   */
+  isRunning() {
+    return this._running;
+  };
+
+  /**
+   * Gets the number of randomly generated dank times to generate each day.
+   * @returns {number}
+   */
+  getNumberOfRandomTimes() {
+    return this._numberOfRandomTimes;
+  };
+
+  /**
+   * Gets the number of points each randomly generated dank time is worth.
+   * @returns {number}
+   */
+  getPointsPerRandomTime() {
+    return this._pointsPerRandomTime;
+  };
+
+  /**
+   * Gets the hour of the last valid dank time being proclaimed.
+   * @returns {number}
+   */
+  getLastHour() {
+    return this._lastHour;
+  };
+
+  /**
+   * Gets the minute of the last valid dank time being proclaimed.
+   * @returns {number}
+   */
+  getLastMinute() {
+    return this._lastMinute;
+  };
+
+  /**
+   * Gets an array of the dank times, sorted by hour and minute.
+   * @returns {DankTime[]}
+   */
+  getDankTimes() {
+    const timesArr = []
+    this._dankTimes.forEach(time => timesArr.push(time));
+    timesArr.sort(DankTime.compare);
+    return timesArr;
+  };
+
+  /**
+   * Gets an unsorted array of the random dank times.
+   * @returns {DankTime[]}
+   */
+  getRandomDankTimes() {
+    return this._randomDankTimes;
+  };
+
+  /**
+   * Gets an array of the users, sorted by scores.
+   * @returns {User[]}
+   */
+  getUsers() {
+    const usersArr = [];
+    this._users.forEach(user => usersArr.push(user));
+    usersArr.sort(User.compare);
+    return usersArr;
+  };
+
+  /**
+   * Generates new random dank times for this chat, clearing old ones.
+   * @returns {DankTime[]} The generated dank times.
+   */
+  generateRandomDankTimes() {
+    this._randomDankTimes = [];
+
+    for (let i = 0; i < this._numberOfRandomTimes; i++) {
+      const date = new Date();
+      date.setHours(date.getHours() + Math.floor(Math.random() * 23));
+      date.setMinutes(Math.floor(Math.random() * 59));
+      date.setTimezone(this._timezone);
+      const text = util.padNumber(date.getHours().toString()) + util.padNumber(date.getMinutes().toString());
+      this._randomDankTimes.push(new DankTime(date.getHours(), date.getMinutes(), [text], this._pointsPerRandomTime));
+    }
+    return this._randomDankTimes;
+  };
+
+  /**
+   * Used by JSON.stringify. Returns a literal representation of this.
+   * @return {Object}
+   */
+  toJSON() {
+    const usersArr = [];
+    this._users.forEach(user => usersArr.push(user));
+    return {
+      id: this._id, timezone: this._timezone, running: this._running, numberOfRandomTimes: this._numberOfRandomTimes,
+      pointsPerRandomTime: this._pointsPerRandomTime, lastHour: this._lastHour, lastMinute: this._lastMinute, users: usersArr,
+      dankTimes: this._dankTimes, randomDankTimes: this._randomDankTimes
+    };
+  };
+
+  /**
+   * Processes a message, awarding or punishing points etc. where applicable.
+   * @param {number} userId
+   * @param {string} userName
+   * @param {string} msgText
+   * @param {number} msgUnixTime
+   * @returns {string} A reply, or nothing if no reply is suitable/needed.
+   */
+  processMessage(userId, userName, msgText, msgUnixTime) {
+    msgText = util.cleanText(msgText);
+
+    // If we are awaiting reset confirmation...
+    if (this._awaitingResetConfirmation) {
+      this._awaitingResetConfirmation = false;
+      if (msgText.toUpperCase() === 'YES') {
+        let message = 'Leaderboard has been reset!\n\n<b>Final leaderboard:</b>';
+        for (const user of this.getUsers()) {
+          const scoreChange = (user.getLastScoreChange() > 0 ? '(+' + user.getLastScoreChange() + ')' :
+            (user.getLastScoreChange() < 0 ? '(' + user.getLastScoreChange() + ')' : ''));
+          message += '\n' + user.getName() + ':    ' + user.getScore() + ' ' + scoreChange;
+          user.resetScore();
         }
-        this._id = id;
-        this.setTimezone(timezone);
-        this.setRunning(running);
-        this.setLastHour(lastHour);
-        this.setLastMinute(lastMinute);
-        if (!(users instanceof Map)) {
-            throw TypeError('The users must be a map!');
-        }
-        this._users = users;
-        if (!(dankTimes instanceof Array)) {
-            throw TypeError('The dank times must be a array!');
-        }
-        this._dankTimes = dankTimes;
-        if (!(randomDankTimes instanceof Array)) {
-            throw TypeError('The random dank times must be a array!');
-        }
-        this._randomDankTimes = randomDankTimes;
-        this.setNumberOfRandomTimes(numberOfRandomTimes);
-        this.setPointsPerRandomTime(pointsPerRandomTime);
-        this._awaitingResetConfirmation = false;
+        return message;
+      }
     }
 
-    /**
-     * Sets the timezone the users are in.
-     * @param {string} newtimezone
-     */
-    setTimezone(newtimezone) {
-        try {
-            new Date().setTimezone(newtimezone);
-        } catch (err) {
-            throw RangeError('Invalid timezone! Examples: \'Europe/Amsterdam\', \'UTC\'.');
+    // If this chat isn't running, don't check anything else.
+    if (!this._running) {
+      return;
+    }
+
+    // Gather dank times from the sent text, returning if none was found.
+    const dankTimesByText = this._getDankTimesByText(msgText);
+    if (dankTimesByText.length < 1) {
+      return;
+    }
+
+    // Get the player, creating him if he doesn't exist yet.
+    if (!this._users.has(userId)) {
+      this._users.set(userId, new User(userId, userName));
+    }
+    const user = this._users.get(userId);
+
+    // Update user name if needed.
+    if (user.getName() !== userName) {
+      user.setName(userName);
+    }
+
+    // Prepare server date object.
+    const serverDate = new Date();
+    serverDate.setTimezone(this._timezone);
+
+    let subtractBy = 0;
+    for (let dankTime of dankTimesByText) {
+      if (serverDate.getHours() === dankTime.getHour() && (serverDate.getMinutes() === dankTime.getMinute()
+        || new Date(msgUnixTime * 1000).getMinutes() === dankTime.getMinute())) {
+
+        // If cache needs resetting, do so and award DOUBLE points to the calling user.
+        if (this._lastHour !== dankTime.getHour() || this._lastMinute !== dankTime.getMinute()) {
+          this._users.forEach(user => user.setCalled(false));
+          this._lastHour = dankTime.getHour();
+          this._lastMinute = dankTime.getMinute();
+          user.addToScore(dankTime.getPoints() * 2);
+          user.setCalled(true);
+        } else if (user.getCalled()) { // Else if user already called this time, remove points.
+          user.addToScore(-dankTime.getPoints());
+        } else {  // Else, award point.
+          user.addToScore(dankTime.getPoints());
+          user.setCalled(true);
         }
-        this._timezone = newtimezone;
-    };
+        return;
+      } else if (dankTime.getPoints() > subtractBy) {
+        subtractBy = dankTime.getPoints();
+      }
+    }
+    // If no match was found, punish the user.
+    user.addToScore(-subtractBy);
+  };
 
-    /**
-     * Sets whether this bot is running for this chat.
-     * @param {boolean} newrunning
-     */
-    setRunning(newrunning) {
-        if (typeof newrunning !== 'boolean') {
-            throw TypeError('The running state must be a boolean!');
+  /**
+   * Sets this chat's awaitingResetConfirmation value.
+   * @param {boolean} awaitingResetConfirmation 
+   */
+  setAwaitingResetConfirmation(awaitingResetConfirmation) {
+    if (typeof awaitingResetConfirmation !== 'boolean') {
+      throw TypeError('The value must be a boolean!');
+    }
+    this._awaitingResetConfirmation = awaitingResetConfirmation;
+  };
+
+  /**
+   * Removes the dank time with the specified hour and minute.
+   * @param {number} hour
+   * @param {number} minute
+   * @returns {boolean} Whether a dank time was found and removed.
+   */
+  removeDankTime(hour, minute) {
+    const dankTime = this._getDankTime(hour, minute);
+    if (dankTime) {
+      this._dankTimes.splice(this._dankTimes.indexOf(dankTime));
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * Gets the normal dank time that has the specified hour and minute.
+   * @param {number} hour 
+   * @param {number} minute 
+   * @returns {DankTime} or undefined if none has the specified hour and minute.
+   */
+  _getDankTime(hour, minute) {
+    for (let dankTime of this._dankTimes) {
+      if (dankTime.getHour() === hour && dankTime.getMinute() === minute) {
+        return dankTime;
+      }
+    }
+  };
+
+  /**
+   * Gets both normal and random dank times that have the specified text.
+   * @param {string} text 
+   * @returns {DankTime[]}
+   */
+  _getDankTimesByText(text) {
+    const found = [];
+    for (let dankTime of this._dankTimes.concat(this._randomDankTimes)) {
+      if (dankTime.hasText(text)) {
+        found.push(dankTime);
+      }
+    }
+    return found;
+  };
+
+  /**
+   * Returns a new Chat parsed from a literal.
+   * @param {Object} literal
+   * @returns {Chat}
+   */
+  static fromJSON(literal) {
+
+    // For backwards compatibility with v.1.0.0.
+    if (!literal.lastHour || !literal.lastMinute) {
+      literal.lastHour = 0;
+      literal.lastMinute = 0;
+
+      for (let dankTime of literal.dankTimes) {
+        if (!dankTime.texts) {
+          dankTime.texts = [dankTime.shoutout];
+          delete dankTime.shoutout;
         }
-        this._running = newrunning;
-    };
-
-    /**
-     * Sets the number of randomly generated dank times to generate each day.
-     * @param {number} newnumberOfRandomTimes
-     * @returns {DankTime[]} The removed times if the old number was > than the new number.
-     */
-    setNumberOfRandomTimes(newnumberOfRandomTimes) {
-        if (typeof newnumberOfRandomTimes !== 'number' || newnumberOfRandomTimes < 0 || newnumberOfRandomTimes % 1 !== 0) {
-            throw TypeError('The number of times must be a whole number greater or equal to 0!');
+      }
+      for (let dankTime of literal.randomDankTimes) {
+        if (!dankTime.texts) {
+          dankTime.texts = [dankTime.shoutout];
+          delete dankTime.shoutout;
         }
-        this._numberOfRandomTimes = newnumberOfRandomTimes;
-        return this._randomDankTimes.splice(newnumberOfRandomTimes)
-    };
+      }
+    }
 
-    /**
-     * Sets the number of points each randomly generated dank time is worth.
-     * @param {number} newpointsPerRandomTime
-     */
-    setPointsPerRandomTime(newpointsPerRandomTime) {
-        if (typeof newpointsPerRandomTime !== 'number' || newpointsPerRandomTime < 1 || newpointsPerRandomTime % 1 !== 0) {
-            throw TypeError('The points must be a whole number greater than 0!');
-        }
-        this._pointsPerRandomTime = newpointsPerRandomTime;
+    const dankTimes = [];
+    literal.dankTimes.forEach(dankTime => dankTimes.push(DankTime.fromJSON(dankTime)));
 
-        // Update existing random times.
-        this._randomDankTimes.forEach(time => time.setPoints(newpointsPerRandomTime));
-    };
+    const randomDankTimes = [];
+    literal.randomDankTimes.forEach(dankTime => randomDankTimes.push(DankTime.fromJSON(dankTime)));
 
-    /**
-     * Sets the hour of the last valid dank time being proclaimed.
-     * @param {number} newlastHour
-     */
-    setLastHour(newlastHour) {
-        if (typeof newlastHour !== 'number' || newlastHour < 0 || newlastHour > 23 || newlastHour % 1 !== 0) {
-            throw TypeError('The hour must be a whole number between 0 and 23!');
-        }
-        this._lastHour = newlastHour;
-    };
+    const users = new Map();
+    literal.users.forEach(user => users.set(user.id, User.fromJSON(user)));
 
-    /**
-     * Sets the minute of the last valid dank time being proclaimed.
-     * @param {number} newlastMinute
-     */
-    setLastMinute(newlastMinute) {
-        if (typeof newlastMinute !== 'number' || newlastMinute < 0 || newlastMinute > 59 || newlastMinute % 1 !== 0) {
-            throw TypeError('The minute must be a whole number between 0 and 59!');
-        }
-        this._lastMinute = newlastMinute;
-    };
-
-    /**
-     * Adds a new normal dank time to this chat, replacing any dank time that has
-     * the same hour and minute.
-     * @param {DankTime} dankTime
-     */
-    addDankTime(dankTime) {
-        const existing = this._getDankTime(dankTime.getHour(), dankTime.getMinute());
-        if (existing) {
-            this._dankTimes.splice(this._dankTimes.indexOf(existing), 1);
-        }
-        this._dankTimes.push(dankTime);
-    };
-
-    /**
-     * Adds a user to this chat.
-     * @param {User} user The user to add.
-     */
-    addUser(user) {
-        this._users.set(user.id, user);
-    };
-
-    /**
-     * Gets the timezone the users are in.
-     * @returns {string}
-     */
-    getTimezone() {
-        return this._timezone;
-    };
-
-    /**
-     * Gets whether this bot is running for this chat.
-     * @returns {boolean}
-     */
-    isRunning() {
-        return this._running;
-    };
-
-    /**
-     * Gets the number of randomly generated dank times to generate each day.
-     * @returns {number}
-     */
-    getNumberOfRandomTimes() {
-        return this._numberOfRandomTimes;
-    };
-
-    /**
-     * Gets the number of points each randomly generated dank time is worth.
-     * @returns {number}
-     */
-    getPointsPerRandomTime() {
-        return this._pointsPerRandomTime;
-    };
-
-    /**
-     * Gets the hour of the last valid dank time being proclaimed.
-     * @returns {number}
-     */
-    getLastHour() {
-        return this._lastHour;
-    };
-
-    /**
-     * Gets the minute of the last valid dank time being proclaimed.
-     * @returns {number}
-     */
-    getLastMinute() {
-        return this._lastMinute;
-    };
-
-    /**
-     * Gets an array of the dank times, sorted by hour and minute.
-     * @returns {DankTime[]}
-     */
-    getDankTimes() {
-        const timesArr = []
-        this._dankTimes.forEach(time => timesArr.push(time));
-        timesArr.sort(DankTime.compare);
-        return timesArr;
-    };
-
-    /**
-     * Gets an unsorted array of the random dank times.
-     * @returns {DankTime[]}
-     */
-    getRandomDankTimes() {
-        return this._randomDankTimes;
-    };
-
-    /**
-     * Gets an array of the users, sorted by scores.
-     * @returns {User[]}
-     */
-    getUsers() {
-        const usersArr = [];
-        this._users.forEach(user => usersArr.push(user));
-        usersArr.sort(User.compare);
-        return usersArr;
-    };
-
-    /**
-     * Generates new random dank times for this chat, clearing old ones.
-     * @returns {DankTime[]} The generated dank times.
-     */
-    generateRandomDankTimes() {
-        this._randomDankTimes = [];
-
-        for (let i = 0; i < this._numberOfRandomTimes; i++) {
-            const date = new Date();
-            date.setHours(date.getHours() + Math.floor(Math.random() * 23));
-            date.setMinutes(Math.floor(Math.random() * 59));
-            date.setTimezone(this._timezone);
-            const text = util.padNumber(date.getHours().toString()) + util.padNumber(date.getMinutes().toString());
-            this._randomDankTimes.push(new DankTime(date.getHours(), date.getMinutes(), [text], this._pointsPerRandomTime));
-        }
-        return this._randomDankTimes;
-    };
-
-    /**
-     * Used by JSON.stringify. Returns a literal representation of this.
-     * @return {Object}
-     */
-    toJSON() {
-        const usersArr = [];
-        this._users.forEach(user => usersArr.push(user));
-        return {
-            id: this._id, timezone: this._timezone, running: this._running, numberOfRandomTimes: this._numberOfRandomTimes,
-            pointsPerRandomTime: this._pointsPerRandomTime, lastHour: this._lastHour, lastMinute: this._lastMinute, users: usersArr,
-            dankTimes: this._dankTimes, randomDankTimes: this._randomDankTimes
-        };
-    };
-
-    /**
-     * Processes a message, awarding or punishing points etc. where applicable.
-     * @param {number} userId
-     * @param {string} userName
-     * @param {string} msgText
-     * @param {number} msgUnixTime
-     * @returns {string} A reply, or nothing if no reply is suitable/needed.
-     */
-    processMessage(userId, userName, msgText, msgUnixTime) {
-        msgText = util.cleanText(msgText);
-
-        // If we are awaiting reset confirmation...
-        if (this._awaitingResetConfirmation) {
-            this._awaitingResetConfirmation = false;
-            if (msgText.toUpperCase() === 'YES') {
-                let message = 'Leaderboard has been reset!\n\n<b>Final leaderboard:</b>';
-                for (const user of this.getUsers()) {
-                    const scoreChange = (user.getLastScoreChange() > 0 ? '(+' + user.getLastScoreChange() + ')' :
-                        (user.getLastScoreChange() < 0 ? '(' + user.getLastScoreChange() + ')' : ''));
-                    message += '\n' + user.getName() + ':    ' + user.getScore() + ' ' + scoreChange;
-                    user.resetScore();
-                }
-                return message;
-            }
-        }
-
-        // If this chat isn't running, don't check anything else.
-        if (!this._running) {
-            return;
-        }
-
-        // Gather dank times from the sent text, returning if none was found.
-        const dankTimesByText = this._getDankTimesByText(msgText);
-        if (dankTimesByText.length < 1) {
-            return;
-        }
-
-        // Get the player, creating him if he doesn't exist yet.
-        if (!this._users.has(userId)) {
-            this._users.set(userId, new User(userId, userName));
-        }
-        const user = this._users.get(userId);
-
-        // Update user name if needed.
-        if (user.getName() !== userName) {
-            user.setName(userName);
-        }
-
-        // Prepare server date object.
-        const serverDate = new Date();
-        serverDate.setTimezone(this._timezone);
-
-        let subtractBy = 0;
-        for (let dankTime of dankTimesByText) {
-            if (serverDate.getHours() === dankTime.getHour() && (serverDate.getMinutes() === dankTime.getMinute()
-                || new Date(msgUnixTime * 1000).getMinutes() === dankTime.getMinute())) {
-
-                // If cache needs resetting, do so and award DOUBLE points to the calling user.
-                if (this._lastHour !== dankTime.getHour() || this._lastMinute !== dankTime.getMinute()) {
-                    this._users.forEach(user => user.setCalled(false));
-                    this._lastHour = dankTime.getHour();
-                    this._lastMinute = dankTime.getMinute();
-                    user.addToScore(dankTime.getPoints() * 2);
-                    user.setCalled(true);
-                } else if (user.getCalled()) { // Else if user already called this time, remove points.
-                    user.addToScore(-dankTime.getPoints());
-                } else {  // Else, award point.
-                    user.addToScore(dankTime.getPoints());
-                    user.setCalled(true);
-                }
-                return;
-            } else if (dankTime.getPoints() > subtractBy) {
-                subtractBy = dankTime.getPoints();
-            }
-        }
-        // If no match was found, punish the user.
-        user.addToScore(-subtractBy);
-    };
-
-    /**
-     * Sets this chat's awaitingResetConfirmation value.
-     * @param {boolean} awaitingResetConfirmation 
-     */
-    setAwaitingResetConfirmation(awaitingResetConfirmation) {
-        if (typeof awaitingResetConfirmation !== 'boolean') {
-            throw TypeError('The value must be a boolean!');
-        }
-        this._awaitingResetConfirmation = awaitingResetConfirmation;
-    };
-
-    /**
-     * Removes the dank time with the specified hour and minute.
-     * @param {number} hour
-     * @param {number} minute
-     * @returns {boolean} Whether a dank time was found and removed.
-     */
-    removeDankTime(hour, minute) {
-        const dankTime = this._getDankTime(hour, minute);
-        if (dankTime) {
-            this._dankTimes.splice(this._dankTimes.indexOf(dankTime));
-            return true;
-        }
-        return false;
-    };
-
-    /**
-     * Gets the normal dank time that has the specified hour and minute.
-     * @param {number} hour 
-     * @param {number} minute 
-     * @returns {DankTime} or undefined if none has the specified hour and minute.
-     */
-    _getDankTime(hour, minute) {
-        for (let dankTime of this._dankTimes) {
-            if (dankTime.getHour() === hour && dankTime.getMinute() === minute) {
-                return dankTime;
-            }
-        }
-    };
-
-    /**
-     * Gets both normal and random dank times that have the specified text.
-     * @param {string} text 
-     * @returns {DankTime[]}
-     */
-    _getDankTimesByText(text) {
-        const found = [];
-        for (let dankTime of this._dankTimes.concat(this._randomDankTimes)) {
-            if (dankTime.hasText(text)) {
-                found.push(dankTime);
-            }
-        }
-        return found;
-    };
-
-    /**
-     * Returns a new Chat parsed from a literal.
-     * @param {Object} literal
-     * @returns {Chat}
-     */
-    static fromJSON(literal) {
-
-        // For backwards compatibility with v.1.0.0.
-        if (!literal.lastHour || !literal.lastMinute) {
-            literal.lastHour = 0;
-            literal.lastMinute = 0;
-
-            for (let dankTime of literal.dankTimes) {
-                if (!dankTime.texts) {
-                    dankTime.texts = [dankTime.shoutout];
-                    delete dankTime.shoutout;
-                }
-            }
-            for (let dankTime of literal.randomDankTimes) {
-                if (!dankTime.texts) {
-                    dankTime.texts = [dankTime.shoutout];
-                    delete dankTime.shoutout;
-                }
-            }
-        }
-
-        const dankTimes = [];
-        literal.dankTimes.forEach(dankTime => dankTimes.push(DankTime.fromJSON(dankTime)));
-
-        const randomDankTimes = [];
-        literal.randomDankTimes.forEach(dankTime => randomDankTimes.push(DankTime.fromJSON(dankTime)));
-
-        const users = new Map();
-        literal.users.forEach(user => users.set(user.id, User.fromJSON(user)));
-
-        return new Chat(literal.id, literal.timezone, literal.running, literal.numberOfRandomTimes, literal.pointsPerRandomTime,
-            literal.lastHour, literal.lastMinute, users, dankTimes, randomDankTimes);
-    };
+    return new Chat(literal.id, literal.timezone, literal.running, literal.numberOfRandomTimes, literal.pointsPerRandomTime,
+      literal.lastHour, literal.lastMinute, users, dankTimes, randomDankTimes);
+  };
 }
 
 // Exports.

--- a/src/chat.js
+++ b/src/chat.js
@@ -48,7 +48,7 @@ class Chat {
     this._randomDankTimes = randomDankTimes;
     this.setNumberOfRandomTimes(numberOfRandomTimes);
     this.setPointsPerRandomTime(pointsPerRandomTime);
-    this._awaitingResetConfirmation = false;
+    this._awaitingResetConfirmation = undefined;
   }
 
   /**
@@ -267,8 +267,8 @@ class Chat {
     msgText = util.cleanText(msgText);
 
     // If we are awaiting reset confirmation...
-    if (this._awaitingResetConfirmation) {
-      this._awaitingResetConfirmation = false;
+    if (this._awaitingResetConfirmation === userId) {
+      this._awaitingResetConfirmation = undefined;
       if (msgText.toUpperCase() === 'YES') {
         let message = 'Leaderboard has been reset!\n\n<b>Final leaderboard:</b>';
         for (const user of this.getUsers()) {
@@ -335,12 +335,13 @@ class Chat {
   };
 
   /**
-   * Sets this chat's awaitingResetConfirmation value.
-   * @param {boolean} awaitingResetConfirmation 
+   * Sets this chat's awaitingResetConfirmation value, which is the
+   * id of the user whose confirmation is awaited.
+   * @param {number} awaitingResetConfirmation 
    */
   setAwaitingResetConfirmation(awaitingResetConfirmation) {
-    if (typeof awaitingResetConfirmation !== 'boolean') {
-      throw TypeError('The value must be a boolean!');
+    if (awaitingResetConfirmation && typeof awaitingResetConfirmation !== 'number') {
+      throw TypeError('The value must be a number or undefined!');
     }
     this._awaitingResetConfirmation = awaitingResetConfirmation;
   };

--- a/src/command.js
+++ b/src/command.js
@@ -5,97 +5,97 @@
  */
 class Command {
 
-    /**
-     * Defines a new command for the Telegram bot.
-     * @param {string} name The name of the command, e.g. 'start'.
-     * @param {string} description Brief description of the command.
-     * @param {object} object The object to call the function on.
-     * @param {function} _function The function which this command calls. Expected to take parameters 'msg' and 'match' and return a string.
-     * @param {boolean} adminOnly Whether only admins can execute this command.
-     * @param {boolean} requiresConfirmation Whether this command requires explicit confirmation.
-     */
-    constructor(name, description, object, _function, adminOnly = false, requiresConfirmation = false) {
-        if (typeof name !== 'string') {
-            throw TypeError('The name must be a string!');
-        }
-        if (typeof description !== 'string') {
-            throw TypeError('The description must be a string!');
-        }
-        if (typeof object !== 'object') {
-            throw TypeError('The object must be an object!');
-        }
-        if (typeof _function !== 'function') {
-            throw TypeError('The function must be a function!');
-        }
-        if (typeof adminOnly !== 'boolean') {
-            throw TypeError('The admin-only setting must be a boolean!');
-        }
-        if (typeof requiresConfirmation !== 'boolean') {
-            throw TypeError('The requires-confirmation setting must be a boolean!');
-        }
-        this._name = name;
-        this._description = description;
-        this._object = object;
-        this._function = _function;
-        this._adminOnly = adminOnly;
-        this._requiresConfirmation = requiresConfirmation;
+  /**
+   * Defines a new command for the Telegram bot.
+   * @param {string} name The name of the command, e.g. 'start'.
+   * @param {string} description Brief description of the command.
+   * @param {object} object The object to call the function on.
+   * @param {function} _function The function which this command calls. Expected to take parameters 'msg' and 'match' and return a string.
+   * @param {boolean} adminOnly Whether only admins can execute this command.
+   * @param {boolean} requiresConfirmation Whether this command requires explicit confirmation.
+   */
+  constructor(name, description, object, _function, adminOnly = false, requiresConfirmation = false) {
+    if (typeof name !== 'string') {
+      throw TypeError('The name must be a string!');
     }
-
-    /**
-     * Gets this command's regex, which is based on its name.
-     * @returns {RegExp}
-     */
-    getRegex() {
-        return RegExp('^\\/' + this._name + '(?:\\@DankTimesBot)?(?:\\s(?:[\\w\\d\\/]+)+)*$', 'i');
-    };
-
-    /**
-     * Gets the name of the command, e.g. 'start'.
-     * @returns {string}
-     */
-    getName() {
-        return this._name;
-    };
-
-    /**
-     * Gets the brief description of the command.
-     * @returns {string}
-     */
-    getDescription() {
-        return this._description;
-    };
-
-    /**
-     * Gets the object on which the command is called.
-     * @returns {Object}
-     */
-    getObject() {
-        return this._object;
-    };
-
-    /**
-     * Gets the function which this command calls.
-     * @returns {function}
-     */
-    getFunction() {
-        return this._function;
-    };
-
-    /**
-     * Gets whether only admins can execute this command.
-     * @returns {boolean}
-     */
-    getAdminOnly() {
-        return this._adminOnly;
-    };
-
-    /**
-     * Gets whether this command requires explicit confirmation.
-     * @returns {boolean}
-     */
-    getRequiresConfirmation() {
-        return this._requiresConfirmation;
+    if (typeof description !== 'string') {
+      throw TypeError('The description must be a string!');
     }
+    if (typeof object !== 'object') {
+      throw TypeError('The object must be an object!');
+    }
+    if (typeof _function !== 'function') {
+      throw TypeError('The function must be a function!');
+    }
+    if (typeof adminOnly !== 'boolean') {
+      throw TypeError('The admin-only setting must be a boolean!');
+    }
+    if (typeof requiresConfirmation !== 'boolean') {
+      throw TypeError('The requires-confirmation setting must be a boolean!');
+    }
+    this._name = name;
+    this._description = description;
+    this._object = object;
+    this._function = _function;
+    this._adminOnly = adminOnly;
+    this._requiresConfirmation = requiresConfirmation;
+  }
+
+  /**
+   * Gets this command's regex, which is based on its name.
+   * @returns {RegExp}
+   */
+  getRegex() {
+    return RegExp('^\\/' + this._name + '(?:\\@DankTimesBot)?(?:\\s(?:[\\w\\d\\/]+)+)*$', 'i');
+  };
+
+  /**
+   * Gets the name of the command, e.g. 'start'.
+   * @returns {string}
+   */
+  getName() {
+    return this._name;
+  };
+
+  /**
+   * Gets the brief description of the command.
+   * @returns {string}
+   */
+  getDescription() {
+    return this._description;
+  };
+
+  /**
+   * Gets the object on which the command is called.
+   * @returns {Object}
+   */
+  getObject() {
+    return this._object;
+  };
+
+  /**
+   * Gets the function which this command calls.
+   * @returns {function}
+   */
+  getFunction() {
+    return this._function;
+  };
+
+  /**
+   * Gets whether only admins can execute this command.
+   * @returns {boolean}
+   */
+  getAdminOnly() {
+    return this._adminOnly;
+  };
+
+  /**
+   * Gets whether this command requires explicit confirmation.
+   * @returns {boolean}
+   */
+  getRequiresConfirmation() {
+    return this._requiresConfirmation;
+  }
 };
 
 // Exports.

--- a/src/commands.js
+++ b/src/commands.js
@@ -48,7 +48,7 @@ class Commands {
     const chat = this._chatRegistry.getOrCreateChat(msg.chat.id);
     if (chat.isRunning()) {
       chat.setRunning(false);
-      return 'DankTimesBot is now stopped! Hit \'/start\' to restart.';     
+      return 'DankTimesBot is now stopped! Hit \'/start\' to restart.';
     }
     return 'DankTimesBot is already stopped!';
   }

--- a/src/commands.js
+++ b/src/commands.js
@@ -60,7 +60,7 @@ class Commands {
    * @returns {string} The response.
    */
   resetChat(msg, match) {
-    this._chatRegistry.getOrCreateChat(msg.chat.id).setAwaitingResetConfirmation(true);
+    this._chatRegistry.getOrCreateChat(msg.chat.id).setAwaitingResetConfirmation(msg.from.id);
     return 'Are you sure? Type \'yes\' to confirm.';
   }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -60,16 +60,8 @@ class Commands {
    * @returns {string} The response.
    */
   resetChat(msg, match) {
-    const chat = this._chatRegistry.getOrCreateChat(msg.chat.id);
-    let message = 'Leaderboard has been reset!\n\n<b>Final leaderboard:</b>';
-
-    for (const user of chat.getUsers()) {
-      const scoreChange = (user.getLastScoreChange() > 0 ? '(+' + user.getLastScoreChange() + ')' :
-        (user.getLastScoreChange() < 0 ? '(' + user.getLastScoreChange() + ')' : ''));
-      message += '\n' + user.getName() + ':    ' + user.getScore() + ' ' + scoreChange;
-    }
-    chat.resetScores();
-    return message;
+    this._chatRegistry.getOrCreateChat(msg.chat.id).setAwaitingResetConfirmation(true);
+    return 'Are you sure? Type \'yes\' to confirm.';
   }
 
   /**

--- a/src/dank-time.js
+++ b/src/dank-time.js
@@ -5,154 +5,154 @@
  */
 class DankTime {
 
-    /**
-     * Creates a new dank time object.
-     * @param {number} hour The hour at which points can be scored.
-     * @param {number} minute The minute at which points can be scored.
-     * @param {string[]} texts The texts to shout at the hour:minute to score points.
-     * @param {number} points The amount of points to reward or confiscate.
-     */
-    constructor(hour, minute, texts, points = 1) {
-        this.setHour(hour);
-        this.setMinute(minute);
-        this.setPoints(points);
-        this.setTexts(texts);
+  /**
+   * Creates a new dank time object.
+   * @param {number} hour The hour at which points can be scored.
+   * @param {number} minute The minute at which points can be scored.
+   * @param {string[]} texts The texts to shout at the hour:minute to score points.
+   * @param {number} points The amount of points to reward or confiscate.
+   */
+  constructor(hour, minute, texts, points = 1) {
+    this.setHour(hour);
+    this.setMinute(minute);
+    this.setPoints(points);
+    this.setTexts(texts);
+  }
+
+  /**
+   * Sets the hour.
+   * @param {number} newhour
+   */
+  setHour(newhour) {
+    if (typeof newhour !== 'number' || newhour < 0 || newhour > 23 || newhour % 1 !== 0) {
+      throw TypeError('The hour must be a whole number between 0 and 23!');
     }
+    this._hour = newhour;
+  };
 
-    /**
-     * Sets the hour.
-     * @param {number} newhour
-     */
-    setHour(newhour) {
-        if (typeof newhour !== 'number' || newhour < 0 || newhour > 23 || newhour % 1 !== 0) {
-            throw TypeError('The hour must be a whole number between 0 and 23!');
-        }
-        this._hour = newhour;
-    };
+  /**
+   * Sets the minute.
+   * @param {number} newminute
+   */
+  setMinute(newminute) {
+    if (typeof newminute !== 'number' || newminute < 0 || newminute > 59 || newminute % 1 !== 0) {
+      throw TypeError('The minute must be a whole number between 0 and 59!');
+    }
+    this._minute = newminute;
+  };
 
-    /**
-     * Sets the minute.
-     * @param {number} newminute
-     */
-    setMinute(newminute) {
-        if (typeof newminute !== 'number' || newminute < 0 || newminute > 59 || newminute % 1 !== 0) {
-            throw TypeError('The minute must be a whole number between 0 and 59!');
-        }
-        this._minute = newminute;
-    };
+  /**
+   * Sets the points.
+   * @param {number} newpoints
+   */
+  setPoints(newpoints) {
+    if (typeof newpoints !== 'number' || newpoints < 1 || newpoints % 1 !== 0) {
+      throw TypeError('The points must be a whole number greater than 0!');
+    }
+    this._points = newpoints;
+  };
 
-    /**
-     * Sets the points.
-     * @param {number} newpoints
-     */
-    setPoints(newpoints) {
-        if (typeof newpoints !== 'number' || newpoints < 1 || newpoints % 1 !== 0) {
-            throw TypeError('The points must be a whole number greater than 0!');
-        }
-        this._points = newpoints;
-    };
+  /**
+   * Sets the texts.
+   * @param {string[]} newtexts
+   */
+  setTexts(newtexts) {
+    if (!(newtexts instanceof Array) || newtexts.length < 1) {
+      throw TypeError('The texts must be a string array containing at least one item!');
+    }
+    newtexts.forEach(entry => {
+      if (typeof entry !== 'string') {
+        throw TypeError('The texts must contain only strings!');
+      }
+    });
+    this._texts = newtexts;
+  };
 
-    /**
-     * Sets the texts.
-     * @param {string[]} newtexts
-     */
-    setTexts(newtexts) {
-        if (!(newtexts instanceof Array) || newtexts.length < 1) {
-            throw TypeError('The texts must be a string array containing at least one item!');
-        }
-        newtexts.forEach(entry => {
-            if (typeof entry !== 'string') {
-                throw TypeError('The texts must contain only strings!');
-            }
-        });
-        this._texts = newtexts;
-    };
+  /**
+   * Gets the texts.
+   * @returns {string[]}
+   */
+  getTexts() {
+    return this._texts;
+  };
 
-    /**
-     * Gets the texts.
-     * @returns {string[]}
-     */
-    getTexts() {
-        return this._texts;
-    };
+  /**
+   * Gets the points.
+   * @returns {number}
+   */
+  getPoints() {
+    return this._points;
+  };
 
-    /**
-     * Gets the points.
-     * @returns {number}
-     */
-    getPoints() {
-        return this._points;
-    };
+  /**
+   * Gets the minute.
+   * @returns {number}
+   */
+  getMinute() {
+    return this._minute;
+  };
 
-    /**
-     * Gets the minute.
-     * @returns {number}
-     */
-    getMinute() {
-        return this._minute;
-    };
+  /**
+   * Gets the hour.
+   * @returns {number}
+   */
+  getHour() {
+    return this._hour;
+  };
 
-    /**
-     * Gets the hour.
-     * @returns {number}
-     */
-    getHour() {
-        return this._hour;
-    };
+  /**
+   * Checks whether this instance contains the text (case-insensitive).
+   * @param {string} text 
+   * @returns True if this instance contains the text, otherwise false.
+   */
+  hasText(text) {
+    text = text.toUpperCase();
+    for (let text2 of this._texts) {
+      if (text2.toUpperCase() === text) {
+        return true;
+      }
+    }
+    return false;
+  };
 
-    /**
-     * Checks whether this instance contains the text (case-insensitive).
-     * @param {string} text 
-     * @returns True if this instance contains the text, otherwise false.
-     */
-    hasText(text) {
-        text = text.toUpperCase();
-        for (let text2 of this._texts) {
-            if (text2.toUpperCase() === text) {
-                return true;
-            }
-        }
-        return false;
-    };
+  /**
+   * Used by JSON.stringify. Returns a literal representation of this.
+   * @return {Object}
+   */
+  toJSON() {
+    return { hour: this._hour, minute: this._minute, texts: this._texts, points: this._points };
+  };
 
-    /**
-     * Used by JSON.stringify. Returns a literal representation of this.
-     * @return {Object}
-     */
-    toJSON() {
-        return { hour: this._hour, minute: this._minute, texts: this._texts, points: this._points };
-    };
+  /**
+   * Returns a new DankTime parsed from a literal.
+   * @param {Object} literal
+   * @returns {DankTime}
+   */
+  static fromJSON(literal) {
+    return new DankTime(literal.hour, literal.minute, literal.texts, literal.points);
+  };
 
-    /**
-     * Returns a new DankTime parsed from a literal.
-     * @param {Object} literal
-     * @returns {DankTime}
-     */
-    static fromJSON(literal) {
-        return new DankTime(literal.hour, literal.minute, literal.texts, literal.points);
-    };
-
-    /**
-     * Compares two dank times using their hour and minute. Used for sorting collections.
-     * @param {DankTime} a
-     * @param {DankTime} b
-     * @returns {number}
-     */
-    static compare(a, b) {
-        if (a.getHour() < b.getHour()) {
-            return -1;
-        }
-        if (a.getHour() > b.getHour()) {
-            return 1;
-        }
-        if (a.getMinute() < b.getMinute()) {
-            return -1;
-        }
-        if (a.getMinute() > b.getMinute()) {
-            return 1;
-        }
-        return 0;
-    };
+  /**
+   * Compares two dank times using their hour and minute. Used for sorting collections.
+   * @param {DankTime} a
+   * @param {DankTime} b
+   * @returns {number}
+   */
+  static compare(a, b) {
+    if (a.getHour() < b.getHour()) {
+      return -1;
+    }
+    if (a.getHour() > b.getHour()) {
+      return 1;
+    }
+    if (a.getMinute() < b.getMinute()) {
+      return -1;
+    }
+    if (a.getMinute() > b.getMinute()) {
+      return 1;
+    }
+    return 0;
+  };
 }
 
 // Exports.

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ tgClient.registerCommand(new Command('start', 'Starts keeping track of scores.',
 tgClient.registerCommand(new Command('stop', 'Stops keeping track of scores.', commands, commands.stopChat, true));
 tgClient.setOnAnyText((msg) => {
   if (msg.text) {
-    chatRegistry.getOrCreateChat(msg.chat.id).processMessage(msg.from.id, msg.from.username || 'anonymous', msg.text, msg.date);
+    return chatRegistry.getOrCreateChat(msg.chat.id).processMessage(msg.from.id, msg.from.username || 'anonymous', msg.text, msg.date);
   }
 });
 

--- a/src/telegram-client.js
+++ b/src/telegram-client.js
@@ -9,102 +9,102 @@ const Command = require('./command.js');
  */
 class TelegramClient {
 
-    /**
-     * Instantiates a new client.
-     * @param {string} apiKey The Telegram API key.
-     */
-    constructor(apiKey) {
-        if (typeof apiKey !== 'string') {
-            throw TypeError('The API key must be a string!');
-        }
-        this._commands = new Map(); // All the available settings of the bot.
-        this._bot = new TelegramBot(apiKey, { polling: true }); // Access to the 'node-telegram-bot-api' library.
+  /**
+   * Instantiates a new client.
+   * @param {string} apiKey The Telegram API key.
+   */
+  constructor(apiKey) {
+    if (typeof apiKey !== 'string') {
+      throw TypeError('The API key must be a string!');
+    }
+    this._commands = new Map(); // All the available settings of the bot.
+    this._bot = new TelegramBot(apiKey, { polling: true }); // Access to the 'node-telegram-bot-api' library.
+  }
+
+  /**
+   * Gets all registered commands.
+   * @returns {Map<string,Command>}
+   */
+  getCommands() {
+    return this._commands;
+  };
+
+  /**
+   * Sets the action to do on ANY incoming text.
+   * @param {function} _function The function to call.
+   */
+  setOnAnyText(_function) {
+    this._bot.on('message', (msg, match) => {
+      const output = _function(msg, match);
+      if (output) {
+        this.sendMessage(msg.chat.id, output);
+      }
+    });
+  };
+
+  /**
+   * Registers a new command, overriding any with the same name.
+   * @param {Command} command
+   */
+  registerCommand(command) {
+    if (!(command instanceof Command)) {
+      throw TypeError('The command must be of type Command!');
+    }
+    this._commands.set(command.getName(), command);
+
+    // Register the command with the bot accordingly.
+    if (!command.getAdminOnly()) {
+      this._bot.onText(command.getRegex(), (msg, match) => {
+        this.sendMessage(msg.chat.id, command.getFunction().call(command.getObject(), msg, match));
+      });
+    } else {
+      this._bot.onText(command.getRegex(), (msg, match) => {
+        this._callFunctionIfUserIsAdmin(msg, match, command.getObject(), command.getFunction());
+      });
+    }
+  };
+
+  /**
+   * Sends a message to the specified chat.
+   * @param {number} chatId The unique Telegram chat id.
+   * @param {string} message In HTML format.
+   */
+  sendMessage(chatId, message) {
+    this._bot.sendMessage(chatId, message, { parse_mode: 'HTML' });
+  };
+
+  /**
+   * Calls the specified function, but only if the calling user is
+   * an admin in his chat, or it is a private chat.
+   * @param {any} msg The message object from the Telegram api.
+   * @param {any} match The matched regex.
+   * @param {Object} object The object to call the function on.
+   * @param {function} _function The function to call. Should have parameters msg, match, chat.
+   */
+  _callFunctionIfUserIsAdmin(msg, match, object, _function) {
+
+    // Only groups have admins, so if this chat isn't a group, continue straight to callback.
+    if (msg.chat.type === 'private') {
+      this.sendMessage(msg.chat.id, _function.call(object, msg, match));
+      return;
     }
 
-    /**
-     * Gets all registered commands.
-     * @returns {Map<string,Command>}
-     */
-    getCommands() {
-        return this._commands;
-    };
+    // Else if this chat is a group, then we must make sure the user is an admin.
+    this._bot.getChatAdministrators(msg.chat.id).then(admins => {
 
-    /**
-     * Sets the action to do on ANY incoming text.
-     * @param {function} _function The function to call.
-     */
-    setOnAnyText(_function) {
-        this._bot.on('message', (msg, match) => { 
-            const output = _function(msg, match);
-            if (output) {
-                this.sendMessage(msg.chat.id, output);
-            }
-        });
-    };
-
-    /**
-     * Registers a new command, overriding any with the same name.
-     * @param {Command} command
-     */
-    registerCommand(command) {
-        if (!(command instanceof Command)) {
-            throw TypeError('The command must be of type Command!');
+      // Check to ensure user is admin. If not, post message.
+      for (const admin of admins) {
+        if (admin.user.id === msg.from.id) {
+          this.sendMessage(msg.chat.id, _function.call(object, msg, match));
+          return;
         }
-        this._commands.set(command.getName(), command);
-
-        // Register the command with the bot accordingly.
-        if (!command.getAdminOnly()) {
-            this._bot.onText(command.getRegex(), (msg, match) => {
-                this.sendMessage(msg.chat.id, command.getFunction().call(command.getObject(), msg, match));
-            });
-        } else {
-            this._bot.onText(command.getRegex(), (msg, match) => {
-                this._callFunctionIfUserIsAdmin(msg, match, command.getObject(), command.getFunction());
-            });
-        }
-    };
-
-    /**
-     * Sends a message to the specified chat.
-     * @param {number} chatId The unique Telegram chat id.
-     * @param {string} message In HTML format.
-     */
-    sendMessage(chatId, message) {
-        this._bot.sendMessage(chatId, message, { parse_mode: 'HTML' });
-    };
-
-    /**
-     * Calls the specified function, but only if the calling user is
-     * an admin in his chat, or it is a private chat.
-     * @param {any} msg The message object from the Telegram api.
-     * @param {any} match The matched regex.
-     * @param {Object} object The object to call the function on.
-     * @param {function} _function The function to call. Should have parameters msg, match, chat.
-     */
-    _callFunctionIfUserIsAdmin(msg, match, object, _function) {
-
-        // Only groups have admins, so if this chat isn't a group, continue straight to callback.
-        if (msg.chat.type === 'private') {
-            this.sendMessage(msg.chat.id, _function.call(object, msg, match));
-            return;
-        }
-
-        // Else if this chat is a group, then we must make sure the user is an admin.
-        this._bot.getChatAdministrators(msg.chat.id).then(admins => {
-
-            // Check to ensure user is admin. If not, post message.
-            for (const admin of admins) {
-                if (admin.user.id === msg.from.id) {
-                    this.sendMessage(msg.chat.id, _function.call(object, msg, match));
-                    return;
-                }
-            }
-            this.sendMessage(msg.chat.id, 'This option is only available to admins!');
-        }).catch(reason => {
-            console.error('Failed to retrieve admin list!\n' + reason);
-            this.sendMessage(msg.chat.id, 'Failed to retrieve admin list! See server console.');
-        });
-    }
+      }
+      this.sendMessage(msg.chat.id, 'This option is only available to admins!');
+    }).catch(reason => {
+      console.error('Failed to retrieve admin list!\n' + reason);
+      this.sendMessage(msg.chat.id, 'Failed to retrieve admin list! See server console.');
+    });
+  }
 };
 
 // Exports.

--- a/src/telegram-client.js
+++ b/src/telegram-client.js
@@ -34,7 +34,12 @@ class TelegramClient {
      * @param {function} _function The function to call.
      */
     setOnAnyText(_function) {
-        this._bot.on('message', (msg, match) => _function(msg, match));
+        this._bot.on('message', (msg, match) => { 
+            const output = _function(msg, match);
+            if (output) {
+                this.sendMessage(msg.chat.id, output);
+            }
+        });
     };
 
     /**

--- a/src/user.js
+++ b/src/user.js
@@ -5,160 +5,162 @@
  */
 class User {
 
-    /**
-     * Creates a new user object.
-     * @param {number} id The unique Telegram user's id.
-     * @param {string} name The Telegram user's name.
-     * @param {number} score The user's DankTimes score.
-     * @param {boolean} called Whether the user called the last dank time already.
-     * @param {number} lastScoreChange The last change to the user's score.
-     */
-    constructor(id, name, score = 0, called = false, lastScoreChange = 0) {
-        if (typeof id !== 'number' || id % 1 !== 0) {
-            throw TypeError('The id must be a whole number!');
-        }
-        this._id = id;
-        this.setName(name);
-        if (typeof score !== 'number' || score % 1 !== 0) {
-            throw TypeError('The score must be a whole number!');
-        }
-        this._score = score;
-        this.setCalled(called);
-        if (typeof lastScoreChange !== 'number' || lastScoreChange % 1 !== 0) {
-            throw TypeError('The last score change must be a whole number!');
-        }
-        this._lastScoreChange = lastScoreChange;
+  /**
+   * Creates a new user object.
+   * @param {number} id The unique Telegram user's id.
+   * @param {string} name The Telegram user's name.
+   * @param {number} score The user's DankTimes score.
+   * @param {boolean} called Whether the user called the last dank time already.
+   * @param {number} lastScoreChange The last change to the user's score.
+   */
+  constructor(id, name, score = 0, called = false, lastScoreChange = 0) {
+    if (typeof id !== 'number' || id % 1 !== 0) {
+      throw TypeError('The id must be a whole number!');
     }
+    this._id = id;
+    this.setName(name);
+    if (typeof score !== 'number' || score % 1 !== 0) {
+      throw TypeError('The score must be a whole number!');
+    }
+    this._score = score;
+    this.setCalled(called);
+    if (typeof lastScoreChange !== 'number' || lastScoreChange % 1 !== 0) {
+      throw TypeError('The last score change must be a whole number!');
+    }
+    this._lastScoreChange = lastScoreChange;
+  }
 
-    /**
-     * Sets the Telegram user's name.
-     * @param {string} newname
-     */
-    setName(newname) {
-        if (typeof newname !== 'string') {
-            throw TypeError('The name must be a string!');
-        }
-        this._name = newname;
-    };
+  /**
+   * Sets the Telegram user's name.
+   * @param {string} newname
+   */
+  setName(newname) {
+    if (typeof newname !== 'string') {
+      throw TypeError('The name must be a string!');
+    }
+    this._name = newname;
+  };
 
-    /**
-     * Sets whether the user called the last dank time already.
-     * @param {boolean} newcalled
-     */
-    setCalled(newcalled) {
-        if (typeof newcalled !== 'boolean') {
-            throw TypeError('The called state must be a boolean!');
-        }
-        this._called = newcalled;
-    };
+  /**
+   * Sets whether the user called the last dank time already.
+   * @param {boolean} newcalled
+   */
+  setCalled(newcalled) {
+    if (typeof newcalled !== 'boolean') {
+      throw TypeError('The called state must be a boolean!');
+    }
+    this._called = newcalled;
+  };
 
-    /**
-     * Gets the unique Telegram user's id.
-     * @returns {number}
-     */
-    getId() {
-        return this._id;
-    };
+  /**
+   * Gets the unique Telegram user's id.
+   * @returns {number}
+   */
+  getId() {
+    return this._id;
+  };
 
-    /**
-     * Gets the Telegram user's name.
-     * @returns {string}
-     */
-    getName() {
-        return this._name;
-    };
+  /**
+   * Gets the Telegram user's name.
+   * @returns {string}
+   */
+  getName() {
+    return this._name;
+  };
 
-    /**
-     * Gets the user's DankTimes score.
-     * @returns {number}
-     */
-    getScore() {
-        return this._score;
-    };
+  /**
+   * Gets the user's DankTimes score.
+   * @returns {number}
+   */
+  getScore() {
+    return this._score;
+  };
 
-    /**
-     * Adds an amount to the user's DankTimes score.
-     * @param {number} amount May be negative.
-     */
-    addToScore(amount) {
-        if (typeof amount !== 'number' || amount % 1 !== 0) {
-            throw TypeError('The amount must be a whole number!');
-        }
-        this._score += amount;
-        this._lastScoreChange += amount;
-    };
+  /**
+   * Adds an amount to the user's DankTimes score.
+   * @param {number} amount May be negative.
+   */
+  addToScore(amount) {
+    if (typeof amount !== 'number' || amount % 1 !== 0) {
+      throw TypeError('The amount must be a whole number!');
+    }
+    this._score += amount;
+    this._lastScoreChange += amount;
+  };
 
-    /**
-     * Resets the DankTimes score.
-     */
-    resetScore() {
-        this._score = 0;
-        this._lastScoreChange = 0;
-        this._called = false;
-    };
+  /**
+   * Resets the DankTimes score.
+   */
+  resetScore() {
+    this._score = 0;
+    this._lastScoreChange = 0;
+    this._called = false;
+  };
 
-    /**
-     * Gets whether the user called the last dank time already.
-     * @returns {boolean} 
-     */
-    getCalled() {
-        return this._called;
-    };
+  /**
+   * Gets whether the user called the last dank time already.
+   * @returns {boolean} 
+   */
+  getCalled() {
+    return this._called;
+  };
 
-    /**
-     * Gets the last change to the user's score.
-     * @returns {number}
-     */
-    getLastScoreChange() {
-        return this._lastScoreChange;
-    };
+  /**
+   * Gets the last change to the user's score.
+   * @returns {number}
+   */
+  getLastScoreChange() {
+    return this._lastScoreChange;
+  };
 
-    /**
-     * Resets the last change to the user's score.
-     */
-    resetLastScoreChange() {
-        this._lastScoreChange = 0;
-    };
+  /**
+   * Resets the last change to the user's score.
+   */
+  resetLastScoreChange() {
+    this._lastScoreChange = 0;
+  };
 
-    /**
-     * Used by JSON.stringify. Returns a literal representation of this.
-     * @return {Object}
-     */
-    toJSON() {
-        return { id: this._id, name: this._name, score: this._score,
-            called: this._called, lastScoreChange: this._lastScoreChange };
+  /**
+   * Used by JSON.stringify. Returns a literal representation of this.
+   * @return {Object}
+   */
+  toJSON() {
+    return {
+      id: this._id, name: this._name, score: this._score,
+      called: this._called, lastScoreChange: this._lastScoreChange
     };
+  };
 
-    /**
-     * Returns a new User parsed from a literal.
-     * @param {Object} literal
-     * @returns {User}
-     */
-    static fromJSON(literal) {
-        return new User(literal.id, literal.name, literal.score, literal.called, literal.lastScoreChange);
-    };
+  /**
+   * Returns a new User parsed from a literal.
+   * @param {Object} literal
+   * @returns {User}
+   */
+  static fromJSON(literal) {
+    return new User(literal.id, literal.name, literal.score, literal.called, literal.lastScoreChange);
+  };
 
-    /**
-     * Compares two users using their score and name. Used for sorting collections.
-     * @param {User} a
-     * @param {User} b
-     * @returns {number}
-     */
-    static compare(a, b) {
-        if (a.getScore() > b.getScore()) {
-            return -1;
-        }
-        if (a.getScore() < b.getScore()) {
-            return 1;
-        }
-        if (a.getName() < b.getName()) {
-            return -1;
-        }
-        if (a.getName() > b.getName()) {
-            return 1;
-        }
-        return 0;
-    };
+  /**
+   * Compares two users using their score and name. Used for sorting collections.
+   * @param {User} a
+   * @param {User} b
+   * @returns {number}
+   */
+  static compare(a, b) {
+    if (a.getScore() > b.getScore()) {
+      return -1;
+    }
+    if (a.getScore() < b.getScore()) {
+      return 1;
+    }
+    if (a.getName() < b.getName()) {
+      return -1;
+    }
+    if (a.getName() > b.getName()) {
+      return 1;
+    }
+    return 0;
+  };
 };
 
 // Exports.

--- a/test/test-command.js
+++ b/test/test-command.js
@@ -3,50 +3,50 @@
 const assert = require('assert');
 const Command = require('../src/command.js');
 
-describe('Command.getRegex()', function() {
+describe('Command.getRegex()', function () {
 
-    const regex = new Command('command', 'command description', {}, () => {}, false, false).getRegex();
-    const tests = [
-        { arg: '/command', expected: true },
+  const regex = new Command('command', 'command description', {}, () => { }, false, false).getRegex();
+  const tests = [
+    { arg: '/command', expected: true },
 
-        { arg: ' /command', expected: false },
-        { arg: '/command ', expected: false },
-        { arg: ' /command ', expected: false },
+    { arg: ' /command', expected: false },
+    { arg: '/command ', expected: false },
+    { arg: ' /command ', expected: false },
 
-        { arg: 'a/command', expected: false },
-        { arg: '/commanda', expected: false },
-        { arg: 'a/commanda', expected: false },
+    { arg: 'a/command', expected: false },
+    { arg: '/commanda', expected: false },
+    { arg: 'a/commanda', expected: false },
 
-        { arg: 'a /command', expected: false },
-        { arg: '/command a', expected: true },
-        { arg: 'a /command a', expected: false },
+    { arg: 'a /command', expected: false },
+    { arg: '/command a', expected: true },
+    { arg: 'a /command a', expected: false },
 
-        { arg: '/command a/a', expected: true },
-        { arg: 'a/a /command', expected: false },
-        { arg: 'a/a /command a/a', expected: false },
+    { arg: '/command a/a', expected: true },
+    { arg: 'a/a /command', expected: false },
+    { arg: 'a/a /command a/a', expected: false },
 
-        { arg: '/command@DankTimesBot', expected: true },
+    { arg: '/command@DankTimesBot', expected: true },
 
-        { arg: ' /command@DankTimesBot', expected: false },
-        { arg: '/command@DankTimesBot ', expected: false },
-        { arg: ' /command@DankTimesBot ', expected: false },
+    { arg: ' /command@DankTimesBot', expected: false },
+    { arg: '/command@DankTimesBot ', expected: false },
+    { arg: ' /command@DankTimesBot ', expected: false },
 
-        { arg: 'a/command@DankTimesBot', expected: false },
-        { arg: '/command@DankTimesBota', expected: false },
-        { arg: 'a/command@DankTimesBota', expected: false },
+    { arg: 'a/command@DankTimesBot', expected: false },
+    { arg: '/command@DankTimesBota', expected: false },
+    { arg: 'a/command@DankTimesBota', expected: false },
 
-        { arg: 'a /command@DankTimesBot', expected: false },
-        { arg: '/command@DankTimesBot a', expected: true },
-        { arg: 'a /command@DankTimesBot a', expected: false },
+    { arg: 'a /command@DankTimesBot', expected: false },
+    { arg: '/command@DankTimesBot a', expected: true },
+    { arg: 'a /command@DankTimesBot a', expected: false },
 
-        { arg: '/command@DankTimesBot a/a', expected: true },
-        { arg: 'a/a /command@DankTimesBot', expected: false },
-        { arg: 'a/a /command@DankTimesBot a/a', expected: false },
-    ];
+    { arg: '/command@DankTimesBot a/a', expected: true },
+    { arg: 'a/a /command@DankTimesBot', expected: false },
+    { arg: 'a/a /command@DankTimesBot a/a', expected: false },
+  ];
 
-    tests.forEach(test => {
-        it('Should produce a valid regex.', function () {
-            assert.equal(regex.test(test.arg), test.expected);
-        });
+  tests.forEach(test => {
+    it('Should produce a valid regex.', function () {
+      assert.equal(regex.test(test.arg), test.expected);
     });
+  });
 });

--- a/test/test-dank-time.js
+++ b/test/test-dank-time.js
@@ -4,17 +4,17 @@ const assert = require('assert');
 const DankTime = require('../src/dank-time.js');
 
 describe('DankTime.compare(a, b)', function (a, b) {
-    const tests = [
-        { args: [new DankTime(13, 37, ['1'], 5), new DankTime(13, 37, ['5'], 1)], expected: 0 },
-        { args: [new DankTime(10, 0, ['2'], 4), new DankTime(9, 10, ['4'], 2)], expected: 1 },
-        { args: [new DankTime(16, 0, ['3'], 3), new DankTime(17, 5, ['3'], 3)], expected: -1 },
-        { args: [new DankTime(15, 30, ['4'], 2), new DankTime(15, 20, ['2'], 4)], expected: 1 },
-        { args: [new DankTime(15, 15, ['5'], 1), new DankTime(15, 30, ['1'], 5)], expected: -1 }
-    ];
+  const tests = [
+    { args: [new DankTime(13, 37, ['1'], 5), new DankTime(13, 37, ['5'], 1)], expected: 0 },
+    { args: [new DankTime(10, 0, ['2'], 4), new DankTime(9, 10, ['4'], 2)], expected: 1 },
+    { args: [new DankTime(16, 0, ['3'], 3), new DankTime(17, 5, ['3'], 3)], expected: -1 },
+    { args: [new DankTime(15, 30, ['4'], 2), new DankTime(15, 20, ['2'], 4)], expected: 1 },
+    { args: [new DankTime(15, 15, ['5'], 1), new DankTime(15, 30, ['1'], 5)], expected: -1 }
+  ];
 
-    tests.forEach(function (test) {
-        it('Should compare correctly.', function () {
-            assert.equal(test.expected, DankTime.compare(test.args[0], test.args[1]));
-        });
+  tests.forEach(function (test) {
+    it('Should compare correctly.', function () {
+      assert.equal(test.expected, DankTime.compare(test.args[0], test.args[1]));
     });
+  });
 });

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -4,29 +4,29 @@ const assert = require('assert');
 const util = require('../src/util.js');
 
 describe('padNumber(msg)', function (msg) {
-    const tests = [
-        { arg: "0", expected: "00" },
-        { arg: "7", expected: "07" },
-        { arg: "13", expected: "13" },
-        { arg: "20", expected: "20" }
-    ];
+  const tests = [
+    { arg: "0", expected: "00" },
+    { arg: "7", expected: "07" },
+    { arg: "13", expected: "13" },
+    { arg: "20", expected: "20" }
+  ];
 
-    tests.forEach(function (test) {
-        it('Should create a valid string (' + test.arg + ')', function () {
-            assert.deepEqual(test.expected, util.padNumber(test.arg));
-        });
+  tests.forEach(function (test) {
+    it('Should create a valid string (' + test.arg + ')', function () {
+      assert.deepEqual(test.expected, util.padNumber(test.arg));
     });
+  });
 
-    const stringTests = [
-        { args: ["13", "37"], expected: "1337" },
-        { args: ["0", "5"], expected: "0005" },
-        { args: ["12", "3"], expected: "1203" },
-        { args: ["3", "12"], expected: "0312" }
-    ];
+  const stringTests = [
+    { args: ["13", "37"], expected: "1337" },
+    { args: ["0", "5"], expected: "0005" },
+    { args: ["12", "3"], expected: "1203" },
+    { args: ["3", "12"], expected: "0312" }
+  ];
 
-    stringTests.forEach(function (test) {
-        it('Should create a valid string: (' + test.args[0] + " + " + test.args[1] + ') => ' + test.expected + ' ?', function () {
-            assert.deepEqual(test.expected, util.padNumber(test.args[0]) + util.padNumber(test.args[1]));
-        });
+  stringTests.forEach(function (test) {
+    it('Should create a valid string: (' + test.args[0] + " + " + test.args[1] + ') => ' + test.expected + ' ?', function () {
+      assert.deepEqual(test.expected, util.padNumber(test.args[0]) + util.padNumber(test.args[1]));
     });
+  });
 });


### PR DESCRIPTION
Implements #31.

58a4cd5 (the second commit) is only auto-formatting, no need to check that.

Check out 608a795 for the original implementation and 7552192 for the change that made the Chat's reset confirmation value's type from a boolean to a number that holds the id of the user whose confirmation is being awaited (or undefined if no confirmation is being awaited). 