### PR TITLE
Implement sending files via plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ typings/
 *.js
 .idea/
 .vscode/settings.json
+tmp/

--- a/src/danktimesbot-controller/danktimesbot-controller-mock.ts
+++ b/src/danktimesbot-controller/danktimesbot-controller-mock.ts
@@ -1,4 +1,4 @@
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File } from "node-telegram-bot-api";
 import { Chat } from "../chat/chat";
 import { CustomEventArguments } from "../plugin-host/plugin-events/event-arguments/custom-event-arguments";
 import { AbstractPlugin } from "../plugin-host/plugin/plugin";
@@ -64,5 +64,13 @@ export class DankTimesBotControllerMock implements IDankTimesBotController {
 
     public onPluginWantsToGetOtherPlugins(callingPlugin: AbstractPlugin): AbstractPlugin[] {
         return [];
+    }
+
+    onPluginWantsToRetrieveFile(chatId: number, fileId: string): Promise<string | void> {
+        return Promise.resolve();
+    }
+
+    onPluginWantsToSendFile(chatId: number, filePath: string, replyToMessageId: number, forceReply: boolean): Promise<void | TelegramBot.Message> {
+        return Promise.resolve();
     }
 }

--- a/src/danktimesbot-controller/danktimesbot-controller.ts
+++ b/src/danktimesbot-controller/danktimesbot-controller.ts
@@ -1,5 +1,5 @@
 import moment from "moment";
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File } from "node-telegram-bot-api";
 import { IChatRegistry } from "../chat-registry/i-chat-registry";
 import { Chat } from "../chat/chat";
 import { IDankTimeScheduler } from "../dank-time-scheduler/i-dank-time-scheduler";
@@ -115,8 +115,22 @@ export class DankTimesBotController implements IDankTimesBotController {
     /**
      * From IPluginListener.
      */
-     public onPluginWantsToParseScoreInput(input: string): number | null {
+    public onPluginWantsToParseScoreInput(input: string): number | null {
         return this.util.parseScoreInput(input);
+    }
+
+    /**
+     * From IPluginListener.
+     */
+    onPluginWantsToRetrieveFile(chatId: number, fileId: string): Promise<string | void> {
+        return this.telegramClient.retrieveFile(chatId, fileId);
+    }
+
+    /**
+     * From IPluginListener.
+     */
+    onPluginWantsToSendFile(chatId: number, filePath: string, replyToMessageId: number, forceReply: boolean): Promise<void | TelegramBot.Message> {
+        return this.telegramClient.sendFile(chatId, filePath, replyToMessageId, forceReply);
     }
 
     /**

--- a/src/plugin-host/plugin/plugin-listener.ts
+++ b/src/plugin-host/plugin/plugin-listener.ts
@@ -1,4 +1,4 @@
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File, PhotoSize } from "node-telegram-bot-api";
 import { Chat } from "../../chat/chat";
 import { CustomEventArguments } from "../plugin-events/event-arguments/custom-event-arguments";
 import { AbstractPlugin } from "./plugin";
@@ -19,11 +19,27 @@ export interface IPluginListener {
                                    replyToMessageId: number, forceReply: boolean): Promise<void | TelegramBot.Message>;
 
     /**
+     * Fired when a plugin wants to send a file / photo to a chat.
+     * @param chatId Chat to send photo to
+     * @param filePath Path to the file on disk to send
+     * @param replyToMessageId Message to respond to
+     * @param forceReply Whether to force the replied-to or tagged user to reply to this message
+     */
+    onPluginWantsToSendFile(chatId: number, filePath: string, replyToMessageId: number, forceReply: boolean): Promise<void | TelegramBot.Message>;
+
+    /**
      * Fired when a plugin wants to delete a chat message.
      * @param chatId The id of the chat to delete a message in.
      * @param messageId The id of the message to delete.
      */
     onPluginWantsToDeleteChatMessage(chatId: number, messageId: number): Promise<void | boolean>;
+
+    /**
+     * Fired when a plugin wants to delete a file. This is likely to be a photo.
+     * @param chatId The id of the chat to retrieve a file from.
+     * @param fileId Id of the file to retrieve.
+     */
+    onPluginWantsToRetrieveFile(chatId: number, fileId: string): Promise<string | void>;
 
     /**
      * Fired when a plugin wants to edit a chat message.

--- a/src/plugin-host/plugin/plugin.ts
+++ b/src/plugin-host/plugin/plugin.ts
@@ -1,4 +1,4 @@
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File, PhotoSize } from "node-telegram-bot-api";
 import { BotCommand } from "../../bot-commands/bot-command";
 import { Chat } from "../../chat/chat";
 import { ChatSettingTemplate } from "../../chat/settings/chat-setting-template";
@@ -174,12 +174,32 @@ export abstract class AbstractPlugin {
     }
 
     /**
+     * Sends a file to the Telegram Bot API.
+     * @param chatId The id of the chat to send a message to.
+     * @param filePath The path to the file we want to send.
+     * @param replyToMessageId The (optional) id of the message to reply to.
+     * @param forceReply Whether to force the replied-to or tagged user to reply to this message.
+     */
+    protected sendFile(chatId: number, filePath: string, replyToMessageId = -1, forceReply = false): Promise<void | TelegramBot.Message> {
+        return this.listener.onPluginWantsToSendFile(chatId, filePath, replyToMessageId, forceReply);
+    }
+
+    /**
    * Deletes a message via the Telegram Bot API.
    * @param chatId The id of the chat to delete a message in.
    * @param messageId The id of the message to delete.
    */
     protected deleteMessage(chatId: number, messageId: number): Promise<boolean | void> {
         return this.listener.onPluginWantsToDeleteChatMessage(chatId, messageId);
+    }
+
+    /**
+     * Retrieves a file from the Telegram Bot API.
+     * @param chatId The id of the chat to retrieve a file from.
+     * @param fileId Id of the file to retrieve.
+     */
+    protected retrieveFile(chatId: number, fileId: string): Promise<string | void> {
+        return this.listener.onPluginWantsToRetrieveFile(chatId, fileId);
     }
 
     /**
@@ -200,7 +220,7 @@ export abstract class AbstractPlugin {
         return this.listener.onPluginWantsToGetChat(chatId);
     }
 
-   /**
+    /**
     * Parses the score input, returning a number if a number could be determined,
     * otherwise returns null.
     * @param input The string input to cleanse to a number.

--- a/src/telegram-client/i-telegram-client.ts
+++ b/src/telegram-client/i-telegram-client.ts
@@ -1,4 +1,4 @@
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File } from "node-telegram-bot-api";
 import { ITelegramClientListener } from "./i-telegram-client-listener";
 
 /**
@@ -61,4 +61,20 @@ export interface ITelegramClient {
      * @return The administrators of the specified chat.
      */
     getChatAdministrators(chatId: number): Promise<TelegramBot.ChatMember[]>;
+
+    /**
+     * retrieves a file with given id from a chat.
+     * @param chatId Id of the chat to retrieve the file from.
+     * @param fileId Id of the file.
+     */
+    retrieveFile(chatId: number, fileId: string): Promise<string | void>;
+
+    /**
+     * Send a file or photo to a chat.
+     * @param chatId Id of the chat to send the file to.
+     * @param filePath Local path to the file on disk.
+     * @param replyToMessageId The (optional) id of the message to reply to.
+     * @param forceReply Whether to force the replied-to or tagged user to reply to this message. False by default.
+     */
+    sendFile(chatId: number, filePath: string, replyToMessageId: number, forceReply: boolean): Promise<TelegramBot.Message | void>;
 }

--- a/src/telegram-client/telegram-client-mock.ts
+++ b/src/telegram-client/telegram-client-mock.ts
@@ -1,4 +1,4 @@
-import TelegramBot from "node-telegram-bot-api";
+import TelegramBot, { File } from "node-telegram-bot-api";
 import { ITelegramClient } from "./i-telegram-client";
 import { ITelegramClientListener } from "./i-telegram-client-listener";
 
@@ -44,5 +44,13 @@ export class TelegramClientMock implements ITelegramClient {
                 is_bot: false,
             },
         }]);
+    }
+
+    public async retrieveFile(chatId: number, fileId: string): Promise<string | void> {
+        // Don't do anything, this is a mock.
+    }
+
+    public async sendFile(chatId: number, filePath: string, replyToMessageId: number, forceReply: boolean): Promise<TelegramBot.Message | void> {
+        // Don't do anything, this is a mock
     }
 }


### PR DESCRIPTION
With this MR, plugins can now download files to a temp directory & send files (e.g. photos) back as messages. For an implementation, check out [DeepFry Plugin](https://github.com/Lerke/DankTimesBot-Plugin-DeepFry).