### PR TITLE
Allow multiline commands

### DIFF
--- a/src/bot-commands/bot-command.ts
+++ b/src/bot-commands/bot-command.ts
@@ -42,7 +42,7 @@ export class BotCommand {
         for (let i = 1; i < this.names.length; i++) {
             regex += `|${this.names[i]}`;
         }
-        regex += `)(?:@${botname})?(?: )?(?:(?<= )(.*))?$`;
+        regex += `)(?:@${botname})?(?: )?(?:(?<= )([\\s\\S]*))?$`;
         return RegExp(regex, "i");
     }
 }


### PR DESCRIPTION
Needed to be able to parse inline spongemock requests consisting of multiple lines of text

/spongemock test
test123
testtest